### PR TITLE
Fix (0-256) should be (0-255)

### DIFF
--- a/book/notes/n_017_01.md
+++ b/book/notes/n_017_01.md
@@ -10,7 +10,7 @@ different manufacturers.
 Modern languages like Python 3 and Ruby store internal string values using the
 [Unicode](https://en.wikipedia.org/wiki/Unicode) character set so they are
 able to represent all characters in all languages around the world.  Modern languages
-tend to represent eight bit values (range 0-256) using a `byte` or similar type.
+tend to represent eight bit values (range 0-255) using a `byte` or similar type.
 Python 2 strings were stored as 8-bit bytes and Python 3 strings are stored as
 32-bit Unicode characters.  Moving to Unicode was a major effort in the Python 2 to Python 3
 transition.


### PR DESCRIPTION
www.cc4e discussion, Report Bugs in Course Material, 8 bit range values. Submitted by a student, "At the end of page 17, 8 bit range should be 0-255 instead of 0-256?".