### PR TITLE
Add Godbolt to the compilers list.

### DIFF
--- a/compilers.php
+++ b/compilers.php
@@ -17,6 +17,8 @@ https://www.tutorialspoint.com/compile_c_online.php
 <li><a href="https://onecompiler.com/c">
 https://onecompiler.com/c
 </a></li>
+<li><a href="https://godbolt.org/z/68oPdEEK9">
+Godbolt Compiler Explorer</a></li>
 </ul>
 <p>
 Please let me know if this list should be updated.  


### PR DESCRIPTION
This pull request adds the <https://godbolt.org> compiler explorer to the C compilers list at <https://cc4e.com>. It is a solid tool, used by many engineers around the globe. The template is specifically made for programming in ANSI C (which can be changed by removing the `-ansi` flag from compiler options). The page includes executable running and assembly viewing capabilities. More windows, such as the GCC tree viewer, etc., can be added by the users by clicking the "Add new..." button.