### PR TITLE
Typos discussion cc4e site

### DIFF
--- a/book/notes/n_009_01.md
+++ b/book/notes/n_009_01.md
@@ -1,6 +1,6 @@
 The 1970's was a time of transition in the amount of memory installed in computers.  The C language `int`
 type was 16 bits in the older but more generally available computers like the PDP/11.  C could be used
-to write programs line the UNIX operating that made efficient use of available memory.
+to write programs like the UNIX operating that made efficient use of available memory.
 In particular the 1978 version of C did not *require* that computers support 32 bit integers.
 But 32,768 is a pretty small number.   The size of an integer affected
 the maximum size of arrays and strings.  A lot of early C programs used the `long` type


### PR DESCRIPTION
21 days ago by Paul S.
On K&R p. 10, in the commentary box about memory, "line the UNIX" should be "like the UNIX" Err, should be p.9