### PR TITLE
Change gets to fgets in description - lessons listing and ccauto

### DIFF
--- a/lessons.json
+++ b/lessons.json
@@ -189,7 +189,7 @@
         ]
         },
         {
-        "title" : "Exercise RS-5: Reading Lines of Input with gets()",
+        "title" : "Exercise RS-5: Reading Lines of Input with fgets()",
         "launch" : "tools/ccauto/",
         "resource_link_id": "rs_05_gets",
         "custom" : [


### PR DESCRIPTION
Assignment description uses fgets, not gets - Exercise RS-5: Write a C program to implement this Python program, using the fgets function instead of scanf. Updates cc4e/lessons.json and ccauto/index.php