### PR TITLE
Missing entry May in months.

### DIFF
--- a/book/code/c_109_01.c
+++ b/book/code/c_109_01.c
@@ -7,6 +7,7 @@ int n;
     "February",
     "March",
     "April",
+    "May",
     "June",
     "July",
     "August",
@@ -14,7 +15,7 @@ int n;
     "October",
     "November",
     "December"
-  } ;
+  };
 
   return((n < 1 || n > 12) ? name[0] : name[n]);
 }


### PR DESCRIPTION
Bug report in discussion - K&R section 5.9: the "name" array inside the month_name(n) function is missing the "May" month entry.