### PR TITLE
Clarify pass-by-value paragraph

### DIFF
--- a/book/notes/n_024_01.md
+++ b/book/notes/n_024_01.md
@@ -12,7 +12,7 @@ an unexpected side effect (and possibly a bug / security flaw) in the calling co
 
 It was a bit of work to make pass by value work in C. C implements a "call stack" where
 a bit of memory is allocated at each function call and C makes a copy of the values in the calling
-code to pass them into the called code in a way that the calling code can see the values
+code to pass them into the called code in a way that the called code can see the values
 and change their local copies without affecting the values in the calling code.  
 
 The same "call stack" that made it possible for C function arguments to be passed by value,

--- a/book/notes/n_024_01.md
+++ b/book/notes/n_024_01.md
@@ -11,8 +11,8 @@ from the called code - so the called code can't easily mess with its arguments a
 an unexpected side effect (and possibly a bug / security flaw) in the calling code.
 
 It was a bit of work to make pass by value work in C. C implements a "call stack" where
-a bit of memory is allocated at each function call and C makes a copy of the values in the calling
-code to pass them into the called code in a way that the called code can see the values
+a bit of memory is allocated at each function call. C then makes a copy of the values in the calling
+code to pass them into the called code. This way, the called code can see the values
 and change their local copies without affecting the values in the calling code.  
 
 The same "call stack" that made it possible for C function arguments to be passed by value,


### PR DESCRIPTION
- Fix possible typo: "calling" to "called". 
- Break up sentences in pass-by-value paragraph to improve readability. 